### PR TITLE
Fix for angular2 RC with webpack build system

### DIFF
--- a/directives/angular2-google-chart.directive.ts
+++ b/directives/angular2-google-chart.directive.ts
@@ -1,4 +1,4 @@
-import {Directive,ElementRef,Input,OnInit} from 'angular2/core';
+import {Directive,ElementRef,Input,OnInit} from '@angular/core';
 declare var google:any;
 declare var googleLoaded:any;
 @Directive({

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "google chart directive for angular2",
   "main": "index.js",
   "dependencies": {
-    "angular2": "2.0.0-beta.17",
+    "@angular/common": "^2.0.0-rc.1",
+    "@angular/core": "^2.0.0-rc.1",
     "systemjs": "0.19.25",
     "es6-shim": "^0.35.0",
     "reflect-metadata": "0.1.2",


### PR DESCRIPTION
Here is a couple of fixes allowing the library to work under webpack compiling and uglyfying.

Without those fixes it was throwing "EXCEPTION: No Directive annotation found on GoogleChart" in a production enviroment.

