### PR TITLE
Chart redraw

### DIFF
--- a/directives/angular2-google-chart.directive.ts
+++ b/directives/angular2-google-chart.directive.ts
@@ -23,6 +23,13 @@ export class GoogleChart implements OnInit {
     google.charts.load('current', {'packages':['corechart', 'gauge']});
      }
     setTimeout(() =>this.drawGraph(this.chartOptions,this.chartType,this.chartData,this._element),1000);
+    this.redrawGraph();
+  }
+  redrawGraph(){
+      var self = this;
+      window.setInterval(function () {
+          self.drawGraph(self.chartOptions,self.chartType,self.chartData,self._element);
+      }, 10000);
   }
   drawGraph (chartOptions,chartType,chartData,ele) {
       google.charts.setOnLoadCallback(drawChart);

--- a/directives/angular2-google-chart.directive.ts
+++ b/directives/angular2-google-chart.directive.ts
@@ -6,7 +6,8 @@ declare var googleLoaded:any;
   properties: [
       'chartType',
       'chartOptions',
-      'chartData'
+      'chartData',
+      'reDraw'
     ]
 })
 export class GoogleChart implements OnInit {
@@ -14,6 +15,7 @@ export class GoogleChart implements OnInit {
   @Input('chartType') public chartType:string;
   @Input('chartOptions') public chartOptions: Object;
   @Input('chartData') public chartData: Object;
+  @Input('reDraw') public reDraw: boolean;
   constructor(public element: ElementRef) {
     this._element = this.element.nativeElement;
   }
@@ -23,7 +25,9 @@ export class GoogleChart implements OnInit {
     google.charts.load('current', {'packages':['corechart', 'gauge']});
      }
     setTimeout(() =>this.drawGraph(this.chartOptions,this.chartType,this.chartData,this._element),1000);
-    this.redrawGraph();
+    if(this.reDraw){
+        this.redrawGraph();
+    }
   }
   redrawGraph(){
       var self = this;

--- a/directives/angular2-google-chart.directive.ts
+++ b/directives/angular2-google-chart.directive.ts
@@ -1,6 +1,6 @@
 import {Directive,ElementRef,Input,OnInit} from 'angular2/core';
 declare var google:any;
-declare var googleLoaded:any = false;
+declare var googleLoaded:any;
 @Directive({
   selector: '[GoogleChart]',
   properties: [


### PR DESCRIPTION
Added functionality, for redrawing a chart if wanted. (Necessary for changing data.)
Just add the `reDraw="true"` to your chart, and the chart will be redrawn after a period of time.
Example:
`<div id="pressureGauge" [chartData]="pressureData" [chartOptions]="pressureChartOptions" chartType="Gauge" reDraw="true"
           GoogleChart ></div>`
